### PR TITLE
include woff2 for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Indigo is Tlon's design language, and a set of web stack implementation tools.
 3. `$ npm install`
 4. `$ npm run start` This will run the sandbox and listen to all Indigo/sandbox changes.
 
+Note: the sandbox is currently broken. (March 12 2019)
+
 ## Usage
 
 When working on Indigo, it is often necessary to see your changes in the context of an app or webpage for visual validation, QC or rapid iteration. Indigo offers ./sandbox to perform such tasks.

--- a/gulp/base64font.js
+++ b/gulp/base64font.js
@@ -6,7 +6,7 @@ module.exports = function(gulp, plugins, src, dest) {
         plugins.base64({
           debug: true,
           maxImageSize: Infinity,
-          extensions: ["ttf", "otf", "woff"]
+          extensions: ["ttf", "otf", "woff", "woff2"]
         })
       )
       .pipe(plugins.concat("_fonts.scss"))


### PR DESCRIPTION
- include woff2 in base64 encoded font scss file.
- update readme with the fact that the sandbox is broken for now.