### PR TITLE
replace broken gulp-better-rollup link in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,18 +15,6 @@
         "through2": "^2.0.3"
       }
     },
-    "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "10.12.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.21.tgz",
-      "integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
-      "dev": true
-    },
     "CSSselect": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
@@ -3453,13 +3441,13 @@
       }
     },
     "gulp-better-rollup": {
-      "version": "github:MikeKovarik/gulp-better-rollup#e84123dff573eb160eea028fe53c61cc0ca61055",
-      "from": "github:MikeKovarik/gulp-better-rollup#greenkeeper/rollup-0.67.3",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-better-rollup/-/gulp-better-rollup-4.0.1.tgz",
+      "integrity": "sha512-oUGrMd+p9umBPoIPYVDxFT4EwCzywh3o8q++eswJyAxrRgYCEM6OOGGxJLG+AmzzjEoiq0cc/ndgF5SH2qW3Fg==",
       "dev": true,
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "plugin-error": "^1.0.1",
-        "rollup": "^0.67.3",
         "vinyl": "^2.1.0",
         "vinyl-sourcemaps-apply": "^0.2.1"
       },
@@ -8441,16 +8429,6 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
-      }
-    },
-    "rollup": {
-      "version": "0.67.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.67.4.tgz",
-      "integrity": "sha512-AVuP73mkb4BBMUmksQ3Jw0jTrBTU1i7rLiUYjFxLZGb3xiFmtVEg40oByphkZAsiL0bJC3hRAJUQos/e5EBd+w==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "0.0.39",
-        "@types/node": "*"
       }
     },
     "rollup-plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@sucrase/gulp-plugin": "^2.0.0",
     "gulp": "^4.0.0",
-    "gulp-better-rollup": "github:MikeKovarik/gulp-better-rollup#greenkeeper/rollup-0.67.3",
+    "gulp-better-rollup": "^4.0.1",
     "gulp-cssimport": "^6.0.0",
     "gulp-cssnano": "^2.1.2",
     "gulp-gzip": "^1.4.2",


### PR DESCRIPTION
I'm not sure if this is the right fix, but I had the following error when running `npm install`:

```
Unhandled rejection Error: Command failed: /usr/local/bin/git checkout greenkeeper/rollup-0.67.3
error: pathspec 'greenkeeper/rollup-0.67.3' did not match any file(s) known to git
```

Manually removed and reinstalled `gulp-better-rollup` and `npm install` finished without errors.